### PR TITLE
Fix blog route optional parameter

### DIFF
--- a/src/routes.test.ts
+++ b/src/routes.test.ts
@@ -1,0 +1,12 @@
+import { routes } from './routes'
+
+describe('routes', () => {
+  describe('blog.path', () => {
+    it('returns /blog when no options provided', () => {
+      expect(routes.blog.path()).toBe('/blog');
+    });
+    it('appends options when provided', () => {
+      expect(routes.blog.path('?page=2')).toBe('/blog?page=2');
+    });
+  });
+});

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,7 +4,7 @@ export const routes = {
         description: "this is a top page"
     },
     blog: {
-        path: (options?: routingOption) => `/blog${options}`,
+        path: (options?: routingOption) => `/blog${options ?? ''}`,
         description: "blog post list",
         detail: {
             path: (contentId: number) => `/blog/${contentId}`,


### PR DESCRIPTION
## Summary
- ensure blog path defaults to `/blog` when no parameters are provided
- add regression test for blog route helper

## Testing
- `yarn test` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6840d51d76c88330906c16b1dce83073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ブログページのパス生成時、不要な「undefined」や「null」がURLに含まれないようになりました。

- **テスト**
  - ブログページのパス生成に関するテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->